### PR TITLE
[eXo Maven Rules] Update add-on to be eXo compatible

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+target/
+pom.xml.tag
+pom.xml.releaseBackup
+pom.xml.versionsBackup
+pom.xml.next
+release.properties
+*.iml
+.idea

--- a/packaging/pom.xml
+++ b/packaging/pom.xml
@@ -13,14 +13,12 @@
     <dependency>
       <groupId>org.exoplatform.addons.monitoring</groupId>
       <artifactId>monitoring-webapps</artifactId>
-      <version>1.0.x-SNAPSHOT</version>
       <type>war</type>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.exoplatform.addons.monitoring</groupId>
       <artifactId>monitoring-services</artifactId>
-      <version>1.0.x-SNAPSHOT</version>
       <scope>provided</scope>
     </dependency>
   </dependencies>

--- a/webapps/pom.xml
+++ b/webapps/pom.xml
@@ -13,7 +13,6 @@
     <dependency>
       <groupId>org.exoplatform.addons.monitoring</groupId>
       <artifactId>monitoring-services</artifactId>
-      <version>1.0.x-SNAPSHOT</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
@@ -83,14 +82,6 @@
     </dependency>
   </dependencies>
   <build>
-    <resources>
-      <resource>
-        <directory>src/main/java</directory>
-        <includes>
-          <include>**/*</include>
-        </includes>
-      </resource>
-    </resources>
     <finalName>monitoring</finalName>
   </build>
 


### PR DESCRIPTION
The main goal of this PR is to refactor the actual code regarding to Maven Rules so that this add-on can be added to the eXo CI:
- [x] Use the `addons-parent-pom` in _`<version>6</version>`_ for targeting eXo Platform 4.3.x and version _`<version>7-M01</version>`_ for targeting eXo Platfiorm 4.4.x
- [x] Define the `groupId` of your addon like this  `org.exoplatform.addons.<project-git-name>` 
  - in your case, it will be `org.exoplatform.addons.monitoring`
- [x] prefix all your `artifactIds` by the latest part of your `groupId`
  - in you case it could be `monitoring-*` (`monitoring-services`...)
- [x] Maven _modules names_
  - [x] Do not use _uppercase letters_ in Maven module names 
  - [x] USe dash `-` to separate words in module name (ie: `my-module-name` )
  - [x] Do not prefix Maven module names by `exo-addons`
- [x] _Folders names_
  - [x] Use the basic eXo rules if your artifactId are too long
    
    ```
    * addon-name
        * packaging
        * services
        * webapps
        - pom.xml
    ```
  - [ ] _OR_ name the folders like the artifactIds
    
    ```
    * monitoring
        * monitoring-packaging
        * monitoring-services
        * monitoring-webapps
        - pom.xml
    ```
  - [x] Dependencies
  - [x] Declare all Dependencies versions as _Maven properties_ in the reactor pom (parent pom) 
    - Hibernate JMX 
      - https://github.com/exo-addons/monitoring/blob/master/portlet/pom.xml#L45
      - https://github.com/exo-addons/monitoring/blob/master/service/pom.xml#L31
    - eXo PLF?  
      - https://github.com/exo-addons/monitoring/blob/master/service/pom.xml#L25
  - [x] Use eXo BOMs as _dependencyManagement_ to add eXo dependencies
  - [ ] Use Juzu BOMs as _dependencyManagement_ to add Juzu dependencies
    - Take a look at task project for that https://github.com/exo-addons/task/blob/develop/pom.xml#L72
  - [x] Do not add XML lines to redefine the actual Maven behavior
    - [x] this build section is useless:  https://github.com/exo-addons/monitoring/blob/master/portlet/pom.xml#L94-L108  
  - [x] Run `mvn -Pformat-pom` to format all pom.xml files with eXo Rules in one command before committing POMs
